### PR TITLE
Enabled multiple states for commands

### DIFF
--- a/VolumeControlPlugin/Commands/InputAdjustment.cs
+++ b/VolumeControlPlugin/Commands/InputAdjustment.cs
@@ -47,7 +47,11 @@ namespace Loupedeck.VolumeControlPlugin.Commands
 
             var device = _deviceHelper.GetDevice(actionParameter);
             if (_deviceHelper.IsDisabled(device))
+{ 
+                //Update image in case the device was disconnected/disabled
+                base.ActionImageChanged(actionParameter);
                 return;
+}
 
             Task.Run(() => device.SetMuteAsync(!device.IsMuted)).GetAwaiter().GetResult();
             base.ActionImageChanged(actionParameter);
@@ -60,7 +64,12 @@ namespace Loupedeck.VolumeControlPlugin.Commands
 
             var device = _deviceHelper.GetDevice(actionParameter);
             if (_deviceHelper.IsDisabled(device))
+{
+                //Update image in case the device was disconnected/disabled
+                base.ActionImageChanged(actionParameter);
                 return;
+}
+                
             
             var volume = device.Volume + ticks;
             if (volume > 100)

--- a/VolumeControlPlugin/Commands/SetDefaultDeviceCommand.cs
+++ b/VolumeControlPlugin/Commands/SetDefaultDeviceCommand.cs
@@ -3,10 +3,12 @@ using System.Threading.Tasks;
 
 using CoreDeviceType = AudioSwitcher.AudioApi.DeviceType;
 using Loupedeck.VolumeControlPlugin.Helpers;
+using AudioSwitcher.AudioApi.CoreAudio;
+using System;
 
 namespace Loupedeck.VolumeControlPlugin.Commands
 {
-    abstract class SetDefaultDeviceCommand : PluginDynamicCommand
+    abstract class SetDefaultDeviceCommand : PluginMultistateDynamicCommand
     {
         private readonly bool _isCommunication;
         private readonly CoreDeviceType _deviceType;
@@ -18,6 +20,12 @@ namespace Loupedeck.VolumeControlPlugin.Commands
 
         protected SetDefaultDeviceCommand(bool isCommunication, CoreDeviceType deviceType, string groupName)
         {
+            PluginLog.Info("Initializing SetDefaultDeviceCommand: "+ groupName);
+            
+            this.AddState("Not default device", "Not selected as default");
+            this.AddState("Default device", "Selected as default");
+            this.AddState("Device disabled", "Not found or disabled"); // Displayed also, when device is disconnected
+
             _isCommunication = isCommunication;
             _deviceType = deviceType;
             _groupName = groupName;
@@ -42,6 +50,7 @@ namespace Loupedeck.VolumeControlPlugin.Commands
             foreach (var device in devices)
             {
                 this.AddParameter(device.Key, device.Value.FullName, _groupName);
+                this.SetCurrentState(device.Key, this.GetDeviceCommandStateIndex(device.Value)); // Set initial state
             }
 
             return true;
@@ -56,11 +65,40 @@ namespace Loupedeck.VolumeControlPlugin.Commands
             if (_deviceHelper.IsDisabled(device))
                 return;
 
+            PluginLog.Info("Setting as default: " + device.FullName);
             if (_isCommunication)
-                Task.Run(() => device.SetAsDefaultCommunicationsAsync()).GetAwaiter().GetResult();
+                Task.Run(() => device.SetAsDefaultCommunicationsAsync()).GetAwaiter().OnCompleted(this.setDefaultCompleted);
             else
-                Task.Run(() => device.SetAsDefaultAsync()).GetAwaiter().GetResult();
+                Task.Run(() => device.SetAsDefaultAsync()).GetAwaiter().OnCompleted(this.setDefaultCompleted);
+         }
+
+        internal void setDefaultCompleted()
+        {
+            foreach (var deviceKey in this.GetParameters())
+            {
+                var deviceKeyValue = deviceKey.Value;
+
+                var device = _deviceHelper.GetDevice(deviceKeyValue);
+                this.SetCurrentState(deviceKeyValue, this.GetDeviceCommandStateIndex(device));
+            }
+
         }
+
+        internal Int32 GetDeviceCommandStateIndex(CoreAudioDevice device)
+        {
+ 
+            if (device is null || _deviceHelper.IsDisabled(device))
+                return 2;   // Disabled
+            
+
+            if (_deviceHelper.IsActive(device, _isCommunication))
+                return 1;   // Selected/default device
+         
+
+            return 0;       // Not default (available) device
+            
+        }
+
     }
 
     class SetDefaultPlaybackDevice : SetDefaultDeviceCommand

--- a/VolumeControlPlugin/Helpers/DeviceHelper.cs
+++ b/VolumeControlPlugin/Helpers/DeviceHelper.cs
@@ -20,7 +20,16 @@ namespace Loupedeck.VolumeControlPlugin.Helpers
             return device.State != DeviceState.Active;
         }
 
-        internal CoreAudioDevice GetDevice( string actionParameter)
+        internal bool IsActive(CoreAudioDevice device, bool isCommunication)
+        {
+            if (device is null)
+                return false;
+         
+            return isCommunication ? device.IsDefaultCommunicationsDevice : device.IsDefaultDevice;
+
+        }
+
+        internal CoreAudioDevice GetDevice(string actionParameter)
         {
             if (string.IsNullOrWhiteSpace(actionParameter))
                 return null;

--- a/VolumeControlPlugin/Helpers/PluginLog.cs
+++ b/VolumeControlPlugin/Helpers/PluginLog.cs
@@ -1,0 +1,33 @@
+namespace Loupedeck.VolumeControlPlugin.Helpers
+{
+    using System;
+
+    // A helper class that enables logging from the plugin code.
+
+    internal static class PluginLog
+    {
+        private static PluginLogFile _pluginLogFile;
+
+        public static void Init(PluginLogFile pluginLogFile)
+        {
+            pluginLogFile.CheckNullArgument(nameof(pluginLogFile));
+            PluginLog._pluginLogFile = pluginLogFile;
+        }
+
+        public static void Verbose(String text) => PluginLog._pluginLogFile?.Verbose(text);
+
+        public static void Verbose(Exception ex, String text) => PluginLog._pluginLogFile?.Verbose(ex, text);
+
+        public static void Info(String text) => PluginLog._pluginLogFile?.Info(text);
+
+        public static void Info(Exception ex, String text) => PluginLog._pluginLogFile?.Info(ex, text);
+
+        public static void Warning(String text) => PluginLog._pluginLogFile?.Warning(text);
+
+        public static void Warning(Exception ex, String text) => PluginLog._pluginLogFile?.Warning(ex, text);
+
+        public static void Error(String text) => PluginLog._pluginLogFile?.Error(text);
+
+        public static void Error(Exception ex, String text) => PluginLog._pluginLogFile?.Error(ex, text);
+    }
+}

--- a/VolumeControlPlugin/VolumeControlPlugin.cs
+++ b/VolumeControlPlugin/VolumeControlPlugin.cs
@@ -1,3 +1,4 @@
+using Loupedeck.VolumeControlPlugin.Helpers;
 using Loupedeck.VolumeControlPlugin.Services;
 
 namespace Loupedeck.VolumeControlPlugin
@@ -8,6 +9,12 @@ namespace Loupedeck.VolumeControlPlugin
 
         public override bool HasNoApplication => true;
         public override bool UsesApplicationApiOnly => true;
+
+        public VolumeControlPlugin()
+        {
+            // Initialize the plugin log.
+            PluginLog.Init(this.Log);
+        }
 
         public override void Load()
         {

--- a/VolumeControlPlugin/VolumeControlPlugin.csproj
+++ b/VolumeControlPlugin/VolumeControlPlugin.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Commands\InputAdjustment.cs" />
     <Compile Include="Commands\SetDefaultDeviceCommand.cs" />
     <Compile Include="Helpers\DeviceHelper.cs" />
+    <Compile Include="Helpers\PluginLog.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\NotificationService.cs" />
     <Compile Include="VolumeControlApplication.cs" />


### PR DESCRIPTION
Multiple states allow to use different icons or background for default devices and disabled devices. All icons are updated, when selection is made. 
At the moment the state change in available devices is not detected and thus state does not change, when devices are enabled or disabled. I have various bluetooth devices and audio mixer that are not always turned on.